### PR TITLE
내 그룹, 그룹 생성 페이지 화면 구현

### DIFF
--- a/src/app/group/create/page.tsx
+++ b/src/app/group/create/page.tsx
@@ -1,0 +1,5 @@
+import CreateGroup from "@/containers/group/create/CreateGroup";
+
+export default function CreateGroupPage() {
+  return <CreateGroup />;
+}

--- a/src/app/group/page.tsx
+++ b/src/app/group/page.tsx
@@ -1,0 +1,5 @@
+import Group from "@/containers/group/Group";
+
+export default function GroupPage() {
+  return <Group />;
+}

--- a/src/components/group/GroupItem.module.css
+++ b/src/components/group/GroupItem.module.css
@@ -1,0 +1,68 @@
+.container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 10px;
+    gap: 11px;
+
+    position: relative;
+    width: 602px;
+    height: 215px;
+
+    background: #ffffff;
+    box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.15);
+    border-radius: 20px;
+}
+
+.group_image {
+    width: 263px;
+    height: 195px;
+    border-radius: 20px;
+}
+
+.group_info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 10px;
+    gap: 14px;
+    width: 308px;
+    height: 152px;
+}
+
+.group_name {
+    font-family: "Inter", sans-serif;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 136%;
+    color: #3e4958;
+}
+
+.group_address {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 20px;
+    color: #3e4958;
+}
+
+.group_member {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.group_member_count,
+.wait_member_count {
+    font-family: "Inter", sans-serif;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 136%;
+    color: #3e4958;
+}
+
+.group_wait_member_count {
+    color: #ffa500;
+}

--- a/src/components/group/GroupItem.tsx
+++ b/src/components/group/GroupItem.tsx
@@ -1,0 +1,29 @@
+import { group } from "@/types/group/group";
+import styles from "./GroupItem.module.css";
+import Image from "next/image";
+
+export default function GroupItem(props: group) {
+  return (
+    <div className={styles.container}>
+      <Image
+        width={150}
+        height={100}
+        src={props.groupImage}
+        alt="group"
+        className={styles.group_image}
+      />
+      <div className={styles.group_info}>
+        <div className={styles.group_name}>{props.name}</div>
+        <div className={styles.group_address}>{props.address}</div>
+        <div className={styles.group_member}>
+          <div className={styles.group_member_count}>
+            인원 <b>{props.memberCount}</b>명
+          </div>
+          <div className={styles.group_wait_member_count}>
+            가입 대기 중인 인원 <b>{props.waitMemberCount}</b>명
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/containers/group/Group.module.css
+++ b/src/containers/group/Group.module.css
@@ -1,0 +1,55 @@
+.container {
+    padding-top: 2rem;
+}
+
+.content_white {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0px;
+    gap: 24px;
+    margin: 0 auto;
+
+    background: #ffffff;
+}
+
+.title {
+    font-size: 35px;
+    font-weight: 700;
+    color: #000000;
+}
+
+.group_container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3rem;
+    padding: 0px;
+    margin: 0 auto;
+}
+
+.no_group {
+    font-size: 20px;
+    font-weight: 600;
+    color: #3e4958;
+}
+
+.create_group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 0px;
+    margin: 0 auto;
+}
+
+.link {
+    font-size: 0.9rem;
+    color: #7B7288;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.link:hover {
+    text-decoration: underline;
+}

--- a/src/containers/group/Group.tsx
+++ b/src/containers/group/Group.tsx
@@ -57,11 +57,11 @@ export default function Group() {
         <div className={styles.group_container}>
           {groups ? (
             groups.map((group) => (
-              <>
-                <Link href={`/group/${group.id}`} key={group.id}>
+              <div key={group.id}>
+                <Link href={`/group/${group.id}`}>
                   <GroupItem key={group.id} {...group} />
                 </Link>
-              </>
+              </div>
             ))
           ) : (
             <div className={styles.no_group}>그룹이 없습니다.</div>

--- a/src/containers/group/Group.tsx
+++ b/src/containers/group/Group.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Spacer from "@/components/Spacer";
+import GroupItem from "@/components/group/GroupItem";
+import styles from "./Group.module.css";
+import Nav from "@/components/nav/Nav";
+import { useState } from "react";
+import { admin } from "@/types/user/admin";
+import { group } from "@/types/group/group";
+import Link from "next/link";
+import PositiveButton from "@/components/buttons/PositiveButton";
+
+export default function Group() {
+  const [user, setUser] = useState<admin | null>({
+    id: 1,
+    name: "홍길동",
+    phone: "010-1234-5678",
+    createdAt: "2021-10-01T00:00:00.000Z",
+    updatedAt: "2021-10-01T00:00:00.000Z",
+  });
+
+  const [groups, setGroups] = useState<group[] | null>([
+    {
+      id: 1,
+      name: "아이사랑수학학원",
+      address: "서울특별시 구로구 항동로 2길 36, 3층",
+      memberCount: 32,
+      waitMemberCount: 5,
+      groupImage: "https://via.placeholder.com/120",
+    },
+    {
+      id: 2,
+      name: "아이사랑영어학원",
+      address: "서울특별시 구로구 항동로 2길 36, 4층",
+      memberCount: 17,
+      waitMemberCount: 2,
+      groupImage: "https://via.placeholder.com/120",
+    },
+  ]);
+
+  return (
+    <>
+      <div className={styles.container}>
+        <Nav
+          text={user ? user.name : "로그인"}
+          positiveText={user ? "내 그룹" : "회원가입"}
+        />
+
+        <Spacer height={7} />
+
+        <div className={styles.content_white}>
+          <div className={styles.title}>{user?.name}님의 그룹</div>
+        </div>
+
+        <Spacer height={5} />
+
+        <div className={styles.group_container}>
+          {groups ? (
+            groups.map((group) => (
+              <>
+                <Link href={`/group/${group.id}`} key={group.id}>
+                  <GroupItem key={group.id} {...group} />
+                </Link>
+              </>
+            ))
+          ) : (
+            <div className={styles.no_group}>그룹이 없습니다.</div>
+          )}
+        </div>
+
+        <Spacer height={3} />
+
+        <div className={styles.create_group}>
+          {groups?.length ? (
+            groups?.length >= 3 ? (
+              <></>
+            ) : (
+              <Link href="/group/create">
+                <PositiveButton text="그룹 생성" />
+              </Link>
+            )
+          ) : (
+            <Link href="/group/create">
+              <PositiveButton text="그룹 생성" />
+            </Link>
+          )}
+          <Link href="/" className={styles.link}>
+            홈으로 돌아갈래요.
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/containers/group/create/CreateGroup.module.css
+++ b/src/containers/group/create/CreateGroup.module.css
@@ -1,0 +1,135 @@
+.create_group_container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #f3f3f3;
+    height: 100vh;
+}
+
+.form_container {
+    width: 50rem;
+    padding: 2rem 4rem 2rem 4rem;
+    background-color: #ffffff;
+    border-radius: 0.7rem;
+}
+
+.title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #000000;
+    text-align: center;
+}
+
+.description {
+    font-size: 1rem;
+    color: #7B7288;
+    margin-top: 0.5rem;
+    text-align: center;
+}
+
+.form {
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.input_group {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.input_group label {
+    font-size: 0.8rem;
+    color: #666666;
+}
+
+.input_group input {
+    width: 100%;
+    height: 3rem;
+    border: 1px solid #cccccc;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    font-size: 1rem;
+    color: #666666;
+}
+
+.input_group button {
+    position: absolute;
+    width: 6rem;
+    height: 2rem;
+    right: 0;
+    margin-top: 0.5rem;
+    margin-right: 0.5rem;
+    border: none;
+    border-radius: 0.25rem;
+    background-color: #b6b6b6;
+    color: #ffffff;
+    font-size: 0.95rem;
+    cursor: pointer;
+}
+
+.button_group {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+}
+
+.cancel_button {
+    width: 6rem;
+    height: 3rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: #b6b6b6;
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+
+}
+
+.submit_button {
+    width: 6rem;
+    height: 3rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: #66DE9D;
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.error_message {
+    font-size: 0.9rem;
+    color: #FF0000;
+    height: 0;
+    text-align: left;
+    padding-left: 0.2rem;
+}
+
+.image_input_container {
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+.image_input {
+    width: 100%;
+    border: none;
+    font-size: 1rem;
+}
+
+.image_input label {
+    font-size: 0.8rem;
+    color: #666666;
+    margin-right: 1rem;
+}
+
+.image_input input {
+    padding-top: 0.3rem;
+    color: #666666;
+}

--- a/src/containers/group/create/CreateGroup.tsx
+++ b/src/containers/group/create/CreateGroup.tsx
@@ -18,10 +18,7 @@ const validationSchema = yup.object().shape({
   emailVerificationCode: yup
     .string()
     .required("이메일 인증번호를 입력해주세요."),
-  businessNumber: yup
-    .string()
-    .required("사업자 번호를 입력해주세요.")
-    .matches(/^\d{10,13}$/, "유효한 사업자 번호를 입력해주세요."),
+  businessNumber: yup.string(),
   address: yup.string().required("대표 주소를 입력해주세요."),
   groupImage: yup.string().required("그룹 이미지를 업로드해주세요."),
 });
@@ -143,12 +140,6 @@ export default function Signup() {
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
               />
-              {formik.touched.businessNumber &&
-                formik.errors.businessNumber && (
-                  <div className={styles.error_message}>
-                    {formik.errors.businessNumber}
-                  </div>
-                )}
             </div>
 
             <div className={styles.input_group}>

--- a/src/containers/group/create/CreateGroup.tsx
+++ b/src/containers/group/create/CreateGroup.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import React from "react";
+import { useFormik } from "formik";
+import * as yup from "yup";
+
+import styles from "./CreateGroup.module.css";
+import Spacer from "@/components/Spacer";
+import Link from "next/link";
+
+const validationSchema = yup.object().shape({
+  groupName: yup
+    .string()
+    .required("그룹명을 입력해주세요.")
+    .min(3, "3자 이상 입력해주세요."),
+  description: yup.string().required("그룹 소개를 입력해주세요."),
+  email: yup.string().required("대표 이메일을 입력해주세요.").email(),
+  emailVerificationCode: yup
+    .string()
+    .required("이메일 인증번호를 입력해주세요."),
+  businessNumber: yup
+    .string()
+    .required("사업자 번호를 입력해주세요.")
+    .matches(/^\d{10,13}$/, "유효한 사업자 번호를 입력해주세요."),
+  address: yup.string().required("대표 주소를 입력해주세요."),
+  groupImage: yup.string().required("그룹 이미지를 업로드해주세요."),
+});
+
+const handleDuplicateCheck = () => {
+  console.log("handleDuplicateCheck");
+};
+
+const handleSendVerificationCode = () => {
+  console.log("handleSendVerificationCode");
+};
+
+const handleVerifyCode = () => {
+  console.log("handleVerifyCode");
+};
+
+export default function Signup() {
+  const formik = useFormik({
+    initialValues: {
+      groupName: "",
+      description: "",
+      email: "",
+      emailVerificationCode: "",
+      businessNumber: "",
+      address: "",
+      groupImage: "",
+    },
+    validationSchema: validationSchema,
+    onSubmit: (values) => {
+      console.log("Form submitted:", values);
+    },
+  });
+
+  return (
+    <>
+      <div className={styles.create_group_container}>
+        <Spacer />
+
+        <div className={styles.title}>와썹 그룹 생성</div>
+        <div className={styles.description}>
+          그룹 정보를 정확히 입력해주세요.
+        </div>
+
+        <Spacer height={5} />
+
+        <div className={styles.form_container}>
+          <form className={styles.form} onSubmit={formik.handleSubmit}>
+            <div className={styles.input_group}>
+              <label htmlFor="groupName">그룹명</label>
+              <div className={styles.inputWithButton}>
+                <input
+                  type="text"
+                  id="groupName"
+                  name="groupName"
+                  placeholder="그룹명을 입력해주세요. (5자 이상)"
+                  value={formik.values.groupName}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                />
+                <button
+                  type="button"
+                  className={styles.button}
+                  onClick={() => handleDuplicateCheck()}
+                >
+                  중복확인
+                </button>
+              </div>
+              {formik.touched.groupName && formik.errors.groupName && (
+                <div className={styles.error_message}>
+                  {formik.errors.groupName}
+                </div>
+              )}
+            </div>
+
+            <div className={styles.input_group}>
+              <label htmlFor="description">그룹 소개</label>
+              <input
+                type="text"
+                id="description"
+                name="description"
+                placeholder="그룹 소개를 입력해주세요."
+                value={formik.values.description}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              {formik.touched.description && formik.errors.description && (
+                <div className={styles.error_message}>
+                  {formik.errors.description}
+                </div>
+              )}
+            </div>
+
+            <div className={styles.input_group}>
+              <label htmlFor="address">대표 주소</label>
+              <input
+                type="text"
+                id="address"
+                name="address"
+                placeholder="대표 주소를 입력해주세요."
+                value={formik.values.address}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              {formik.touched.address && formik.errors.address && (
+                <div className={styles.error_message}>
+                  {formik.errors.address}
+                </div>
+              )}
+            </div>
+
+            <div className={styles.input_group}>
+              <label htmlFor="businessNumber">사업자 번호 (선택)</label>
+              <input
+                type="text"
+                id="businessNumber"
+                name="businessNumber"
+                placeholder="사업자 번호를 입력해주세요."
+                value={formik.values.businessNumber}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              {formik.touched.businessNumber &&
+                formik.errors.businessNumber && (
+                  <div className={styles.error_message}>
+                    {formik.errors.businessNumber}
+                  </div>
+                )}
+            </div>
+
+            <div className={styles.input_group}>
+              <label htmlFor="email">대표 이메일</label>
+              <div className={styles.inputWithButton}>
+                <input
+                  type="text"
+                  id="email"
+                  name="email"
+                  placeholder="대표 이메일을 입력해주세요."
+                  value={formik.values.email}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                />
+                <button
+                  type="button"
+                  className={styles.button}
+                  onClick={handleSendVerificationCode}
+                >
+                  발송하기
+                </button>
+              </div>
+              {formik.touched.email && formik.errors.email && (
+                <div className={styles.error_message}>
+                  {formik.errors.email}
+                </div>
+              )}
+            </div>
+
+            <div className={styles.input_group}>
+              <label htmlFor="emailVerificationCode">인증번호</label>
+              <div className={styles.input_with_button}>
+                <input
+                  type="text"
+                  id="emailVerificationCode"
+                  name="emailVerificationCode"
+                  placeholder="인증번호를 입력해주세요."
+                  value={formik.values.emailVerificationCode}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                />
+                <button
+                  type="button"
+                  className={styles.button}
+                  onClick={handleVerifyCode}
+                >
+                  인증하기
+                </button>
+              </div>
+              {formik.touched.emailVerificationCode &&
+                formik.errors.emailVerificationCode && (
+                  <div className={styles.error_message}>
+                    {formik.errors.emailVerificationCode}
+                  </div>
+                )}
+            </div>
+
+            <div className={styles.image_input}>
+              <label htmlFor="groupImage">그룹 이미지</label>
+              <div className={styles.image_input_container}>
+                <input
+                  type="file"
+                  id="groupImage"
+                  name="groupImage"
+                  accept="image/*"
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                  className={styles.image_input}
+                  aria-label="그룹 이미지 업로드"
+                />
+              </div>
+              {formik.touched.groupImage && formik.errors.groupImage && (
+                <div className={styles.error_message}>
+                  {formik.errors.groupImage}
+                </div>
+              )}
+            </div>
+
+            <div className={styles.button_group}>
+              <Link href="/group">
+                <button type="button" className={styles.cancel_button}>
+                  돌아가기
+                </button>
+              </Link>
+              <button type="submit" className={styles.submit_button}>
+                가입하기
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <Spacer />
+      </div>
+    </>
+  );
+}

--- a/src/containers/signup/Signup.module.css
+++ b/src/containers/signup/Signup.module.css
@@ -62,7 +62,6 @@
     width: 6rem;
     height: 2rem;
     right: 0;
-    padding: 0.5rem 1rem;
     margin-top: 0.5rem;
     margin-right: 0.5rem;
     border: none;

--- a/src/types/group/group.ts
+++ b/src/types/group/group.ts
@@ -1,0 +1,8 @@
+export type group = {
+    id: number;
+    name: string;
+    address: string;
+    memberCount: number;
+    waitMemberCount: number;
+    groupImage: string;
+};

--- a/src/types/user/admin.ts
+++ b/src/types/user/admin.ts
@@ -1,0 +1,7 @@
+export type admin = {
+    id: number;
+    name: string;
+    phone: string;
+    createdAt: string;
+    updatedAt: string;
+};


### PR DESCRIPTION
### 내용
- #17 
- 내 그룹 페이지 화면을 구현했습니다.
- 그룹 생성 페이지 화면을 구현했습니다.

### 결과 (내 그룹)
- 내 그룹 페이지 화면 구현
- 그룹을 선택할 수 있습니다.
- 만약 3개(기본 생성 할당량)를 이미 생성한 경우 그룹 생성 버튼이 보이지 않습니다.
<img width="1280" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/11bff05d-73e3-4901-833b-ce75765dd1d7">
<img width="1289" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/ba027d1a-1bad-45a5-b688-b94c2328945b">
<img width="1275" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/b3733914-4020-47c5-b34b-8ae036ce0b01">

### 결과 (그룹 생성)
- 그룹 생성 페이지 화면 구현
- 회원가입 페이지와 유사합니다. 디자인 참고 #10 
<img width="993" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/b7936daf-0206-4015-acd2-8a753e6a516c">
<img width="992" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/e33bfb00-4fa2-4301-88a0-f69f440e9755">