### PR TITLE
[close #30] 대표 주소 입력 시 팝업 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "framer-motion": "^11.0.20",
         "next": "14.1.3",
         "react": "^18",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18",
         "react-hook-form": "^7.51.1",
         "react-use-pagination": "^2.0.1",
@@ -6269,6 +6270,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "framer-motion": "^11.0.20",
     "next": "14.1.3",
     "react": "^18",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18",
     "react-hook-form": "^7.51.1",
     "react-use-pagination": "^2.0.1",

--- a/src/containers/group/create/CreateGroup.module.css
+++ b/src/containers/group/create/CreateGroup.module.css
@@ -9,7 +9,7 @@
 
 .form_container {
     width: 50rem;
-    padding: 2rem 4rem 2rem 4rem;
+    padding: 1.2rem 2.5rem 1.2rem 2.5em;
     background-color: #ffffff;
     border-radius: 0.7rem;
 }
@@ -32,7 +32,7 @@
     padding: 2rem;
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 1.1rem;
 }
 
 .input_group {

--- a/src/containers/group/create/CreateGroup.tsx
+++ b/src/containers/group/create/CreateGroup.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { useFormik } from "formik";
 import * as yup from "yup";
+import { useDaumPostcodePopup } from "react-daum-postcode";
 
 import styles from "./CreateGroup.module.css";
 import Spacer from "@/components/Spacer";
@@ -44,6 +45,7 @@ export default function Signup() {
       emailVerificationCode: "",
       businessNumber: "",
       address: "",
+      addressDetail: "",
       groupImage: "",
     },
     validationSchema: validationSchema,
@@ -51,6 +53,43 @@ export default function Signup() {
       console.log("Form submitted:", values);
     },
   });
+
+  const scriptUrl =
+    "//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js";
+  const open = useDaumPostcodePopup(scriptUrl);
+
+  const handleComplete = (data: {
+    address: any;
+    addressType: string;
+    bname: string;
+    buildingName: string;
+  }) => {
+    let fullAddress = data.address;
+    let extraAddress = "";
+
+    if (data.addressType === "R") {
+      if (data.bname !== "") {
+        extraAddress += data.bname;
+      }
+      if (data.buildingName !== "") {
+        extraAddress +=
+          extraAddress !== "" ? `, ${data.buildingName}` : data.buildingName;
+      }
+      fullAddress += extraAddress !== "" ? ` (${extraAddress})` : "";
+    }
+
+    formik.setFieldValue("address", fullAddress);
+  };
+
+  const handleClick = () => {
+    open({
+      onComplete: handleComplete,
+      width: 500,
+      height: 600,
+      left: window.screen.width / 2 - 500 / 2,
+      top: window.screen.height / 2 - 600 / 2,
+    });
+  };
 
   return (
     <>
@@ -113,20 +152,43 @@ export default function Signup() {
 
             <div className={styles.input_group}>
               <label htmlFor="address">대표 주소</label>
-              <input
-                type="text"
-                id="address"
-                name="address"
-                placeholder="대표 주소를 입력해주세요."
-                value={formik.values.address}
-                onChange={formik.handleChange}
-                onBlur={formik.handleBlur}
-              />
+              <div className={styles.inputWithButton}>
+                <input
+                  type="text"
+                  id="address"
+                  name="address"
+                  placeholder="대표 주소를 입력해주세요."
+                  value={formik.values.address}
+                  onChange={formik.handleChange}
+                  readOnly
+                  onBlur={formik.handleBlur}
+                />
+                <button
+                  type="button"
+                  className={styles.button}
+                  onClick={handleClick}
+                >
+                  주소찾기
+                </button>
+              </div>
               {formik.touched.address && formik.errors.address && (
                 <div className={styles.error_message}>
                   {formik.errors.address}
                 </div>
               )}
+            </div>
+
+            <div className={styles.input_group}>
+              <label htmlFor="businessNumber">추가 주소 (선택)</label>
+              <input
+                type="text"
+                id="businessNumber"
+                name="addressDetail"
+                placeholder="추가 주소를 입력해주세요."
+                value={formik.values.addressDetail}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
             </div>
 
             <div className={styles.input_group}>


### PR DESCRIPTION
### 내용
- #30 
- Daum Postcode 서비스의 팝업을 사용합니다.
```
"react-daum-postcode": "^3.1.3"
```
- 우편번호 주소 이후에 추가적인 주소도 입력할 수 있도록 추가합니다. (예시 : 1103호)

### 결과
<img width="1040" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/8d807e80-a6ff-494f-a73d-985279c92959">
<img width="1023" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/87527212-eb76-4992-9772-b12c850d75a5">


https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/44c84b13-e4cd-4e63-8736-5379f938e378
