### PR TITLE
[close #53] 그룹 인원 추가 페이지 기능 구현

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -24,6 +24,7 @@ jobs:
           NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
+          NEXT_PUBLIC_INVITE_URL: ${{ secrets.INVITE_URL }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/src/containers/group/detail/contents/MemberManage.module.css
+++ b/src/containers/group/detail/contents/MemberManage.module.css
@@ -1,8 +1,10 @@
 .container {
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     width: 100%;
-    height: 78vh;
+    height: 44vh;
+    min-height: 44rem;
     margin-top: 1rem;
     padding: 2rem;
     background-color: #ffffff;

--- a/src/containers/group/detail/contents/MemberManage.tsx
+++ b/src/containers/group/detail/contents/MemberManage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 
 import { useState, useEffect } from "react";
@@ -17,6 +18,7 @@ import {
 } from "@nextui-org/react";
 import usePagination from "@/hooks/usePagination";
 import MemberInvite from "./MemberInvite";
+import { getGroupMembers } from "@/services/invite/invite";
 
 type ManageType = "info" | "invite";
 
@@ -26,162 +28,55 @@ type MemberManageProps = {
 
 export default function MemberManage(props: MemberManageProps) {
   const [members, setMembers] = useState<member[]>([]);
+  const [currentMembers, setCurrentMembers] = useState<member[]>([]);
   const [selectedMember, setSelectedMember] = useState<member | null>(null);
   const [searchKeyword, setSearchKeyword] = useState("");
-  const { currentPage, totalPages, setPage } = usePagination(1, 16);
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
   const [selectedModal, setSelectedModal] = useState<string>("");
   const [selectedPage, setSelectedPage] = useState<ManageType>("info");
+  const { currentPage, totalPages, setTotalItems, setPage } = usePagination(1);
 
   const filteredMembers = useMemo(() => {
-    return members.filter((member) =>
-      member.name.toLowerCase().includes(searchKeyword.toLowerCase())
-    );
+    if (searchKeyword) {
+      return members.filter((member) =>
+        member.name.toLowerCase().includes(searchKeyword.toLowerCase())
+      );
+    } else {
+      return members;
+    }
   }, [members, searchKeyword]);
 
   useEffect(() => {
-    // 추후 API로 대체
-    const fetchMembers = async (currentPage: number) => {
-      // const response = await fetch("/api/members");
-      // const data = await response.json();
-      // 임시 데이터
-      if (currentPage === 2) {
-        setMembers([
-          {
-            id: 9,
-            name: "김민수",
-            phone: "010-9012-3456",
-            birth: "2008-09-09",
-            description: "김민수입니다.",
-          },
-          {
-            id: 10,
-            name: "박민수",
-            phone: "010-0123-4567",
-            birth: "2009-10-10",
-            description: "박민수입니다.",
-          },
-          {
-            id: 11,
-            name: "이민수",
-            phone: "010-1234-5678",
-            birth: "2010-11-11",
-            description: "이민수입니다.",
-          },
-          {
-            id: 12,
-            name: "정민수",
-            phone: "010-2345-6789",
-            birth: "2011-12-12",
-            description: "정민수입니다.",
-          },
-          {
-            id: 13,
-            name: "김영수",
-            phone: "010-3456-7890",
-            birth: "2012-01-01",
-            description: "김영수입니다.",
-          },
-          {
-            id: 14,
-            name: "박영수",
-            phone: "010-4567-8901",
-            birth: "2013-02-02",
-            description: "박영수입니다.",
-          },
-          {
-            id: 15,
-            name: "이영희",
-            phone: "010-5678-9012",
-            birth: "2014-03-03",
-            description: "이영희입니다.",
-          },
-          {
-            id: 16,
-            name: "정영희",
-            phone: "010-6789-0123",
-            birth: "2015-04-04",
-            description: "정영희입니다.",
-          },
-        ]);
-      } else {
-        setMembers([
-          {
-            id: 1,
-            name: "홍길동",
-            phone: "010-1234-5678",
-            birth: "2000-01-01",
-            description: "홍길동입니다.",
-          },
-          {
-            id: 2,
-            name: "김철수",
-            phone: "010-2345-6789",
-            birth: "2001-02-02",
-            description: "김철수입니다.",
-          },
-          {
-            id: 3,
-            name: "이영희",
-            phone: "010-3456-7890",
-            birth: "2002-03-03",
-            description: "이영희입니다.",
-          },
-          {
-            id: 4,
-            name: "박영수",
-            phone: "010-4567-8901",
-            birth: "2003-04-04",
-            description: "박영수입니다.",
-          },
-          {
-            id: 5,
-            name: "정민수",
-            phone: "010-5678-9012",
-            birth: "2004-05-05",
-            description: "정민수입니다.",
-          },
-          {
-            id: 6,
-            name: "김영수",
-            phone: "010-6789-0123",
-            birth: "2005-06-06",
-            description: "김영수입니다.",
-          },
-          {
-            id: 7,
-            name: "박민수",
-            phone: "010-7890-1234",
-            birth: "2006-07-07",
-            description: "박민수입니다.",
-          },
-          {
-            id: 8,
-            name: "이민수",
-            phone: "010-8901-2345",
-            birth: "2007-08-08",
-            description: "이민수입니다.",
-          },
-        ]);
-      }
-    };
+    const data = getGroupMembers(props.id);
+    data.then((data) => {
+      setMembers(data);
+    });
+  }, [props.id, selectedPage]);
 
-    fetchMembers(currentPage);
-  }, [currentPage]);
+  useEffect(() => {
+    const start = (currentPage - 1) * 7;
+    const end = start + 7;
+    setCurrentMembers(filteredMembers.slice(start, end));
+    setTotalItems(filteredMembers.length);
+  }, [currentPage, filteredMembers]);
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchKeyword(e.target.value);
   };
 
   const handleMemberClick = (id: number) => {
-    setSelectedMember(members.find((member) => member.id === id) || null);
+    setSelectedMember(
+      filteredMembers.find((member) => member.id === id) || null
+    );
     setSelectedModal("info");
     onOpen();
     console.log(`Member ${id} clicked!`);
   };
 
   const handleSendMessage = (id: number) => {
-    setSelectedMember(members.find((member) => member.id === id) || null);
+    setSelectedMember(
+      filteredMembers.find((member) => member.id === id) || null
+    );
     setSelectedModal("message");
     onOpen();
     console.log(`Send message to member ${id}`);
@@ -217,7 +112,7 @@ export default function MemberManage(props: MemberManageProps) {
           초대하기
         </Button>
       </div>
-      {selectedPage == "info" ? (
+      {selectedPage === "info" ? (
         <>
           <div className={styles.container}>
             <div className={styles.content}>
@@ -233,47 +128,44 @@ export default function MemberManage(props: MemberManageProps) {
               </div>
 
               <div className={styles.list}>
-                {filteredMembers.map((member) => (
-                  <>
-                    <div className={styles.list_item}>
-                      <div
-                        key={member.id}
-                        className={styles.list_item_name}
-                        onClick={() => handleMemberClick(member.id)}
-                      >
-                        {member.name}
-                      </div>
-                      <div className={styles.buttons}>
-                        <Image
-                          src="/message.png"
-                          alt="message"
-                          width={36}
-                          height={36}
-                          className={styles.button_image}
-                          onClick={() => handleSendMessage(member.id)}
-                        ></Image>
-                        <Image
-                          src="/edit.png"
-                          alt="edit"
-                          width={36}
-                          height={36}
-                          className={styles.button_image}
-                          onClick={() => handleEditMember(member.id)}
-                        ></Image>
-                      </div>
+                {filteredMembers.length === 0 && <div>인원이 없습니다.</div>}
+                {currentMembers.map((member) => (
+                  <div key={member.id} className={styles.list_item}>
+                    <div
+                      className={styles.list_item_name}
+                      onClick={() => handleMemberClick(member.id)}
+                    >
+                      {member.name}
                     </div>
-                  </>
+                    <div className={styles.buttons}>
+                      <Image
+                        src="/message.png"
+                        alt="message"
+                        width={36}
+                        height={36}
+                        className={styles.button_image}
+                        onClick={() => handleSendMessage(member.id)}
+                      />
+                      <Image
+                        src="/edit.png"
+                        alt="edit"
+                        width={36}
+                        height={36}
+                        className={styles.button_image}
+                        onClick={() => handleEditMember(member.id)}
+                      />
+                    </div>
+                  </div>
                 ))}
               </div>
-
-              <div className={styles.pagination}>
-                <Pagination
-                  showControls
-                  total={totalPages}
-                  initialPage={1}
-                  onChange={(page) => setPage(page)}
-                />
-              </div>
+            </div>
+            <div className={styles.pagination}>
+              <Pagination
+                showControls
+                total={totalPages}
+                initialPage={1}
+                onChange={(page) => setPage(page)}
+              />
             </div>
 
             <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
@@ -297,7 +189,7 @@ export default function MemberManage(props: MemberManageProps) {
                               전화번호
                             </h3>
                             <p className={styles.member_info}>
-                              {selectedMember.phone}
+                              {selectedMember.phoneNumber}
                             </p>
                             <h3 className={styles.modal__content_Title}>
                               생년월일
@@ -309,7 +201,7 @@ export default function MemberManage(props: MemberManageProps) {
                               특이사항
                             </h3>
                             <p className={styles.member_info}>
-                              {selectedMember.description}
+                              {selectedMember.specifics}
                             </p>
                           </>
                         )}
@@ -338,7 +230,7 @@ export default function MemberManage(props: MemberManageProps) {
                               전화번호
                             </h3>
                             <p className={styles.member_info}>
-                              {selectedMember.phone}
+                              {selectedMember.phoneNumber}
                             </p>
                             <h3 className={styles.modal__content_Title}>
                               메시지

--- a/src/containers/group/invite/GroupInvite.tsx
+++ b/src/containers/group/invite/GroupInvite.tsx
@@ -4,43 +4,53 @@ import { useFormik } from "formik";
 import * as yup from "yup";
 import styles from "./GroupInvite.module.css";
 import Spacer from "@/components/Spacer";
+import { joinGroup } from "@/services/invite/invite";
 
 const validationSchema = yup.object().shape({
-  childName: yup.string().required("자녀 이름을 입력해주세요."),
+  name: yup.string().required("자녀 이름을 입력해주세요."),
   phoneNumber: yup
     .string()
     .required("전화번호를 입력해주세요.")
     .matches(/^\d{10,11}$/, "유효한 전화번호를 입력해주세요."),
-  childBirth: yup.string().required("자녀 생일을 입력해주세요."),
-  specialNote: yup.string().optional(),
+  birth: yup.string().required("자녀 생일을 입력해주세요."),
+  specifics: yup.string().optional(),
   groupCode: yup.string().required("그룹 고유 코드를 입력해주세요."),
 });
 
 export default function GroupInvite() {
   const formik = useFormik({
     initialValues: {
-      childName: "",
+      name: "",
       phoneNumber: "",
-      childBirth: "",
-      specialNote: "",
+      birth: "",
+      specifics: "",
       groupCode: "",
     },
     validationSchema: validationSchema,
     onSubmit: (values) => {
       console.log("Form submitted:", values);
-      // API 연결
-      // signupChild(values);
     },
   });
 
-  const requestSignup = () => {
+  const requestJoinGroup = async () => {
     if (!formik.isValid) {
       return;
     }
 
-    console.log("Signup requested:", formik.values);
-    // API 연결
-    // signupChild(formik.values);
+    const data = joinGroup({
+      name: formik.values.name,
+      phoneNumber: formik.values.phoneNumber,
+      birth: formik.values.birth,
+      specifics: formik.values.specifics,
+      groupCode: formik.values.groupCode,
+    });
+
+    if (await data) {
+      alert("가입 신청이 완료되었습니다.");
+      window.location.href = "/";
+    } else {
+      alert("가입 신청에 실패했습니다. 다시 시도해주세요.");
+    }
   };
 
   return (
@@ -58,20 +68,18 @@ export default function GroupInvite() {
         <div className={styles.form_container}>
           <form className={styles.form} onSubmit={formik.handleSubmit}>
             <div className={styles.input_group}>
-              <label htmlFor="childName">자녀 이름</label>
+              <label htmlFor="name">자녀 이름</label>
               <input
                 type="text"
-                id="childName"
-                name="childName"
+                id="name"
+                name="name"
                 placeholder="자녀 이름을 입력해주세요."
-                value={formik.values.childName}
+                value={formik.values.name}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
               />
-              {formik.touched.childName && formik.errors.childName && (
-                <div className={styles.error_message}>
-                  {formik.errors.childName}
-                </div>
+              {formik.touched.name && formik.errors.name && (
+                <div className={styles.error_message}>{formik.errors.name}</div>
               )}
             </div>
             <div className={styles.input_group}>
@@ -92,34 +100,34 @@ export default function GroupInvite() {
               )}
             </div>
             <div className={styles.input_group}>
-              <label htmlFor="childBirth">자녀 생일</label>
+              <label htmlFor="birth">자녀 생일</label>
               <input
                 type="date"
-                id="childBirth"
-                name="childBirth"
-                value={formik.values.childBirth}
+                id="birth"
+                name="birth"
+                value={formik.values.birth}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
               />
-              {formik.touched.childBirth && formik.errors.childBirth && (
+              {formik.touched.birth && formik.errors.birth && (
                 <div className={styles.error_message}>
-                  {formik.errors.childBirth}
+                  {formik.errors.birth}
                 </div>
               )}
             </div>
             <div className={styles.input_group}>
-              <label htmlFor="specialNote">자녀 특이사항</label>
+              <label htmlFor="specifics">자녀 특이사항</label>
               <textarea
-                id="specialNote"
-                name="specialNote"
+                id="specifics"
+                name="specifics"
                 placeholder="자녀의 특이사항을 입력해주세요."
-                value={formik.values.specialNote}
+                value={formik.values.specifics}
                 onChange={formik.handleChange}
                 onBlur={formik.handleBlur}
               />
-              {formik.touched.specialNote && formik.errors.specialNote && (
+              {formik.touched.specifics && formik.errors.specifics && (
                 <div className={styles.error_message}>
-                  {formik.errors.specialNote}
+                  {formik.errors.specifics}
                 </div>
               )}
             </div>
@@ -145,7 +153,7 @@ export default function GroupInvite() {
               <button
                 type="submit"
                 className={styles.submit_button}
-                onClick={requestSignup}
+                onClick={requestJoinGroup}
               >
                 가입하기
               </button>

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect } from "react";
 
-var itemsPerPage = 8;
+var itemsPerPage = 7;
 
-export default function usePagination(initialPage = 1, totalItems = 0) {
+export default function usePagination(initialPage = 1) {
   const [currentPage, setCurrentPage] = useState(initialPage);
+  const [totalItems, setTotalItems] = useState(1);
   const [totalPages, setTotalPages] = useState(Math.ceil(totalItems / itemsPerPage));
 
   const setPage = (pageNumber: number) => {
@@ -18,6 +19,7 @@ export default function usePagination(initialPage = 1, totalItems = 0) {
   return {
     currentPage,
     totalPages,
+    setTotalItems,
     setPage,
   };
 }

--- a/src/services/invite/invite.ts
+++ b/src/services/invite/invite.ts
@@ -80,3 +80,30 @@ export const getGroupMembers = async (id: number) => {
         console.error(error);
     }
 };
+
+export type RequestJoinGroup = {
+    name: string;
+    phoneNumber: string;
+    birth: string;
+    specifics: string;
+    groupCode: string;
+};
+
+export const joinGroup = async (requestJoinGroup: RequestJoinGroup) => {
+    try {
+        const response = await axios.post(`/api/members/join`, {
+            name: requestJoinGroup.name,
+            phoneNumber: requestJoinGroup.phoneNumber,
+            birth: requestJoinGroup.birth,
+            specifics: requestJoinGroup.specifics,
+            groupCode: requestJoinGroup.groupCode,
+        }, {
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
+        return response.status === 200;
+    } catch (error) {
+        console.error(error);
+    }
+}

--- a/src/services/invite/invite.ts
+++ b/src/services/invite/invite.ts
@@ -10,7 +10,7 @@ export type RequestSendInvite = {
 
 export const sendInviteMessage = async (requestSendInvite: RequestSendInvite) => {
     try {
-        const response = await axios.post(`/api/groups/invite/send?id=${requestSendInvite.id}`, {
+        const response = await axios.post(`/api/groups/send?id=${requestSendInvite.id}`, {
             phoneNumber: requestSendInvite.phoneNumber,
             link: requestSendInvite.link,
         }, {
@@ -27,7 +27,7 @@ export const sendInviteMessage = async (requestSendInvite: RequestSendInvite) =>
 
 export const acceptInvite = async (id: number) => {
     try {
-        const response = await axios.post(`/api/groups/invite/accept?id=${id}`, {}, {
+        const response = await axios.post(`/api/groups/accept?id=${id}`, {}, {
             headers: {
                 "Content-Type": "application/json",
                 "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
@@ -41,7 +41,7 @@ export const acceptInvite = async (id: number) => {
 
 export const rejectInvite = async (id: number) => {
     try {
-        const response = await axios.post(`/api/groups/invite/reject?id=${id}`, {}, {
+        const response = await axios.post(`/api/groups/reject?id=${id}`, {}, {
             headers: {
                 "Content-Type": "application/json",
                 "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
@@ -55,7 +55,7 @@ export const rejectInvite = async (id: number) => {
 
 export const getWaitingMembers = async (id: number) => {
     try {
-        const response = await axios.get(`/api/groups/invite/waiting?id=${id}`, {
+        const response = await axios.get(`/api/groups/members?id=${id}&type=waiting`, {
             headers: {
                 "Content-Type": "application/json",
                 "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
@@ -66,3 +66,17 @@ export const getWaitingMembers = async (id: number) => {
         console.error(error);
     }
 }
+
+export const getGroupMembers = async (id: number) => {
+    try {
+        const response = await axios.get(`/api/groups/members?id=${id}&type=accepted`, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
+        });
+        return response.data;
+    } catch (error) {
+        console.error(error);
+    }
+};

--- a/src/types/user/member.ts
+++ b/src/types/user/member.ts
@@ -1,7 +1,7 @@
 export type member = {
     id: number;
     name: string;
-    phone: string;
+    phoneNumber: string;
     birth: string;
-    description: string;
+    specifics: string;
 };


### PR DESCRIPTION
### 내용

- #51 에서 구현한 화면에 필요한 기능을 구현합니다.
- 그룹 초대, 그룹 가입, 대기 중인 인원 조회, 가입 수락 및 거절, 가입된 인원 조회 기능을 구현합니다.
- 추가로 검색이나, 검색으로 변경되는 인원 수에 맞게 페이지네이션 기능도 작동하도록 수정했습니다.

### 결과

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/e91c0e10-1614-4466-bdd0-242514d9004a

- 먼저 그룹 가입을 원하는 분(학부모)께 초대 메시지를 전송합니다.

![IMG_04F4DAC48000-1](https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/f146c815-b5c0-4a9a-9770-921b09e19db6)

- 초대 메시지는 다음과 같습니다. 

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/d1652195-62fe-4870-bf43-4ec13d150e9c

- 초대 메시지에 있는 링크로 접속하여 자녀의 정보와 초대 코드(그룹 고유 코드)를 작성하여 가입 신청을 진행합니다.

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/36f45fdb-5418-4025-aa0e-762f220c9516

- 신청 후 가입 대기 중인 인원이 있을 경우 관리자는 내 그룹 페이지에서 확인할 수 있습니다.
- 대기 중인 멤버 목록을 보고 수락하거나 거절할 수 있습니다.
- 수락하는 경우 인원 확인 탭에서 조회할 수 있으며 상세 정보도 확인할 수 있습니다. (거절하는 경우에는 대기 중인 인원 목록에서 제거됩니다.)
