### PR TITLE
[close #57] 그룹 관리 페이지에서 그룹 이름이 나오도록 수정

### DIFF
--- a/src/containers/group/detail/GroupDetail.tsx
+++ b/src/containers/group/detail/GroupDetail.tsx
@@ -25,9 +25,9 @@ export default function GroupDetail() {
       const data = await getGroup(selectedId);
       setGroupData({
         id: data.id,
-        name: data.name,
+        name: data.groupName,
         address: data.address,
-        groupImage: data.groupImage,
+        groupImage: data.imageUrl,
         description: data.groupDescription,
         businessNumber: data.businessNumber,
       });


### PR DESCRIPTION
### 내용
- #57 
- API 응답을 저장하는 과정에서 생긴 이슈입니다.
- 오탈자를 고쳐 수정합니다.

### 결과
<img width="1025" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/fc94efc7-3ce4-45c6-b795-5e02a155fd12">