### PR TITLE
[close #60] 그룹 정보 수정 시 이미지 업로드 방식 변경

### DIFF
--- a/src/containers/group/detail/contents/GroupManage.tsx
+++ b/src/containers/group/detail/contents/GroupManage.tsx
@@ -29,7 +29,6 @@ const validationSchema = yup.object().shape({
 
 export default function GroupManage(props: GroupManageProps) {
   const [groupDetail, setGroupDetail] = useState<groupInfo | null>(null);
-  const [groupImage, setGroupImage] = useState<File | null>(null);
   const [imageName, setImageName] = useState<string>("");
 
   useEffect(() => {
@@ -101,22 +100,19 @@ export default function GroupManage(props: GroupManageProps) {
     });
   };
 
-  const uploadGroupImage = () => {
-    if (!groupImage) {
+  const uploadGroupImage = (imageFile: File | null) => {
+    if (!imageFile) {
       return;
     }
     const uploadFileName = uuid() + ".png";
     setImageName(uploadFileName);
     const imageRef = ref(firebaseStorage, uploadFileName);
-    uploadBytes(imageRef, groupImage);
+    uploadBytes(imageRef, imageFile);
   };
 
   const requestUpdateGroup = async () => {
     try {
-      if (groupImage) {
-        uploadGroupImage();
-      }
-      const response = await updateGroup(props.id, {
+      const response = updateGroup(props.id, {
         description: formik.values.description,
         address: formik.values.address + " " + formik.values.addressDetail,
         imageUrl: imageName || "default.png",
@@ -231,7 +227,7 @@ export default function GroupManage(props: GroupManageProps) {
                   accept="image/*"
                   onChange={(event) => {
                     formik.setFieldValue("groupImage", event.target.files?.[0]);
-                    setGroupImage(event.target.files?.[0] || null);
+                    uploadGroupImage(event.target.files?.[0] as File);
                   }}
                   onBlur={formik.handleBlur}
                   className={styles.image_input}


### PR DESCRIPTION
### 내용
- #60 
- 기존에는 파일을 선택하고 수정 버튼을 누르는 순간에 이미지를 업로드하고 파일명을 가져오는 방식이었지만, 이제 파일을 선택하는 순간 미리 업로드하여 파일명을 준비하고 사용자가 수정 버튼을 누르면 수정 요청만 보내는 방식으로 수정하였습니다.