### PR TITLE
[close #59] 출석 화면 및 링크 생성 화면 구현

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -25,6 +25,7 @@ jobs:
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           NEXT_PUBLIC_INVITE_URL: ${{ secrets.INVITE_URL }}
+          NEXT_PUBLIC_WEB_BASE_URL: ${{ secrets.WEB_BASE_URL }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -1,17 +1,5 @@
 import AttendancePad from "@/containers/group/detail/contents/AttendancePad";
-import { Button } from "@nextui-org/react";
-import Image from "next/image";
-import Link from "next/link";
 
 export default function AttendancePage() {
-  return (
-    <>
-      <div>
-        <AttendancePad />
-        <Button color="primary">
-          <Link href="/">돌아가기</Link>
-        </Button>
-      </div>
-    </>
-  );
+  return <AttendancePad />;
 }

--- a/src/containers/group/detail/GroupDetail.tsx
+++ b/src/containers/group/detail/GroupDetail.tsx
@@ -99,7 +99,7 @@ export default function GroupDetail() {
       case "manage":
         return <MemberManage id={id} />;
       case "attendance":
-        return <Attendance />;
+        return <Attendance id={id} />;
       case "notice":
         return <GroupNotice />;
       case "edit":

--- a/src/containers/group/detail/contents/Attendance.module.css
+++ b/src/containers/group/detail/contents/Attendance.module.css
@@ -51,8 +51,7 @@
     color: #666;
 }
 
-.absent,
-.late {
+.absent {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -62,21 +61,23 @@
     padding: 1rem;
 }
 
-.absentTitle,
-.lateTitle {
+.absentTitle {
     font-weight: bold;
     color: #333;
 }
 
-.absentList,
-.lateList {
+.absentList {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.absentList li,
-.lateList li {
+.absentList li {
     margin-bottom: 0.3rem;
     color: #666;
+}
+
+.modalButton {
+    color: #fff;
+    background-color: #9DC0FA;
 }

--- a/src/containers/group/detail/contents/Attendance.tsx
+++ b/src/containers/group/detail/contents/Attendance.tsx
@@ -1,36 +1,121 @@
-import { Button } from "@nextui-org/react";
-import styles from "./Attendance.module.css";
-import Link from "next/link";
+"use client";
 
-export default function Attendance() {
+import styles from "./Attendance.module.css";
+import { useState } from "react";
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+  Snippet,
+  Spinner,
+  Progress,
+  Button,
+} from "@nextui-org/react";
+import {
+  ResponseCode,
+  getAttendancePageUniqueCode,
+} from "@/services/attendance/attendance";
+
+type AttendanceProps = {
+  id: number;
+};
+
+export default function Attendance(props: AttendanceProps) {
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+  const [attendanceCode, setAttendanceCode] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const generateAttendanceCode = async () => {
+    onOpen();
+    setIsLoading(true);
+    // const code = await getAttendanceCode();
+    const code = "Ri8DW19O"; // 임시 코드 API 개발 중
+    if (!code) {
+      alert("출석 링크를 생성하는데 실패했습니다. 잠시 후 다시 시도해주세요.");
+      return;
+    }
+    setAttendanceCode(code);
+    setIsLoading(false);
+  };
+
+  async function getAttendanceCode(): Promise<string> {
+    const response = (await getAttendancePageUniqueCode(
+      props.id
+    )) as ResponseCode;
+    return response.code;
+  }
+
+  function generateAttendancePageLink() {
+    return `${process.env.NEXT_PUBLIC_WEB_BASE_URL}/attendance?code=${attendanceCode}`;
+  }
+
   return (
     <>
       <h1 className={styles.title}>출결 관리</h1>
       <div className={styles.container}>
         <div className={styles.buttonContainer}>
-          <Button className={styles.button}>
-            <Link href="/attendance">출석</Link>
+          <Button className={styles.button} onClick={generateAttendanceCode}>
+            출석 링크
           </Button>
         </div>
         <div className={styles.summary}>
-          <div className={styles.attendanceRate}>금일 출석률: 88% (22/25)</div>
+          <Progress
+            label="금일 출석률"
+            aria-label="Downloading..."
+            size="md"
+            value={88}
+            color="primary"
+            showValueLabel={true}
+            className={styles.attendanceRate}
+          />
           <div className={styles.absent}>
-            <h3 className={styles.absentTitle}>금일 결석 인원</h3>
+            <h3 className={styles.absentTitle}>금일 미출석 인원</h3>
             <ul className={styles.absentList}>
               <li>김철수</li>
               <li>홍길동</li>
               <li>이영희</li>
             </ul>
           </div>
-          <div className={styles.late}>
-            <h3 className={styles.lateTitle}>금일 지각 인원</h3>
-            <ul className={styles.lateList}>
-              <li>박철수</li>
-              <li>김영희</li>
-            </ul>
-          </div>
         </div>
       </div>
+
+      <Modal
+        size="xl"
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        isDismissable={false}
+        isKeyboardDismissDisabled={true}
+      >
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-0">
+                출석 페이지
+              </ModalHeader>
+              <ModalBody>
+                <>
+                  <div>아래 링크는 24시간 동안 유효합니다.</div>
+                  {isLoading ? (
+                    <Spinner size="lg" />
+                  ) : (
+                    <Snippet symbol="" variant="bordered">
+                      {generateAttendancePageLink()}
+                    </Snippet>
+                  )}
+                </>
+              </ModalBody>
+              <ModalFooter>
+                <Button className={styles.modalButton} onPress={onClose}>
+                  확인
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/src/containers/group/detail/contents/AttendancePad.module.css
+++ b/src/containers/group/detail/contents/AttendancePad.module.css
@@ -15,19 +15,48 @@
     background-color: #f5f5f5;
 }
 
+.title {
+    font-size: 1.55rem;
+    font-weight: 700;
+    color: #333;
+    text-align: left;
+    margin-bottom: 1rem;
+}
+
+.title span {
+    color: #9DC0FA;
+}
+
 .inputNumber {
     width: 100%;
     max-width: 400px;
     margin-bottom: 2rem;
 }
 
-.inputNumber input {
+.numberDisplay {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
     width: 100%;
+    min-height: 7rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    font-size: 1.6rem;
+    text-align: center;
+}
+
+.num1,
+.num2,
+.num3,
+.num4 {
+    width: 25%;
     padding: 1rem;
+    min-height: 4.7rem;
     font-size: 1.6rem;
     border: 1px solid #ddd;
     border-radius: 4px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border: 2px solid #c0d7fc;
     text-align: center;
     pointer-events: none;
 }
@@ -58,17 +87,20 @@
     cursor: pointer;
 }
 
-.previousButton {
-    background-color: #ddd;
+.resetButton {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: #4b4b4b;
+    background-color: #e6e6e6;
 }
 
 .confirmButton {
     width: 100%;
-    height: 50px;
+    height: 4rem;
     font-size: 1.4rem;
     border: none;
     border-radius: 4px;
-    background-color: #3b82f6;;
+    background-color: #9DC0FA;
     color: #fff;
     cursor: pointer;
 }

--- a/src/containers/group/detail/contents/AttendancePad.module.css
+++ b/src/containers/group/detail/contents/AttendancePad.module.css
@@ -1,41 +1,24 @@
-/* 헤더 */
-.header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 2rem;
-}
-
-.header img {
-    width: 80px;
-}
-
-.header .userInfo {
-    display: flex;
-    align-items: center;
-}
-
-.header .userInfo span {
-    margin-right: 1rem;
-}
-
-/* 컨테이너 */
 .container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-    height: calc(100vh - 4rem);
-    /* 헤더 제외 */
-    padding: 2rem;
     background-color: #f5f5f5;
 }
 
-/* 번호 입력 칸 */
+.contents {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 95%;
+    height: 100vh;
+    max-width: 500px;
+    margin: 0 auto;
+    padding: 3rem;
+    background-color: #f5f5f5;
+}
+
 .inputNumber {
     width: 100%;
-    max-width: 300px;
-    margin-bottom: 1rem;
+    max-width: 400px;
+    margin-bottom: 2rem;
 }
 
 .inputNumber input {
@@ -46,27 +29,28 @@
     border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     text-align: center;
+    pointer-events: none;
 }
 
 .inputNumber .errorMessage {
     color: red;
-    font-size: 0.8rem;
+    font-size: 1.2rem;
     margin-top: 0.5rem;
+    margin-left: 0.2rem;
 }
 
-/* 넘버 패드 */
 .numberPad {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    grid-gap: 0.5rem;
+    grid-gap: 1rem;
     width: 100%;
-    max-width: 300px;
-    margin-bottom: 1rem;
+    max-width: 400px;
+    margin-bottom: 2rem;
 }
 
 .numberButton {
     width: 100%;
-    height: 50px;
+    height: 70px;
     font-size: 1.4rem;
     border: 1px solid #ddd;
     border-radius: 4px;
@@ -78,15 +62,13 @@
     background-color: #ddd;
 }
 
-/* 버튼 */
 .confirmButton {
     width: 100%;
-    max-width: 300px;
     height: 50px;
     font-size: 1.4rem;
     border: none;
     border-radius: 4px;
-    background-color: #000;
+    background-color: #3b82f6;;
     color: #fff;
     cursor: pointer;
 }

--- a/src/containers/group/detail/contents/AttendancePad.tsx
+++ b/src/containers/group/detail/contents/AttendancePad.tsx
@@ -2,10 +2,23 @@
 
 import React, { useState } from "react";
 import styles from "./AttendancePad.module.css";
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+  Button,
+} from "@nextui-org/react";
+
+type AttendanceType = "ok" | "already" | "duplicate" | "notfound";
 
 export default function AttendancePad() {
   const [inputNumber, setInputNumber] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+  const [attendanceType, setAttendanceType] = useState<AttendanceType>("ok");
 
   const handleNumberClick = (number: number) => {
     if (inputNumber.length < 4) {
@@ -18,23 +31,23 @@ export default function AttendancePad() {
   };
 
   const handleConfirmClick = () => {
-    if (inputNumber.length === 4) {
-      // TODO: API 연동
-      // 서버에 4자리 숫자 전송
-      // 서버에서 출석 정보 확인 후 결과 표시
-    } else {
+    if (inputNumber.length !== 4) {
       setErrorMessage("4자리 숫자를 입력하세요.");
+      return;
     }
+    setErrorMessage("");
+    setInputNumber("");
+    onOpen();
+  };
+
+  const requestAttendance = () => {
+    // TODO: 출석 요청
+    setAttendanceType("ok");
   };
 
   return (
-    <>
-      <header className={styles.header}>
-        <div className={styles.userInfo}>
-          <span>이름:</span>
-        </div>
-      </header>
-      <div className={styles.container}>
+    <div className={styles.container}>
+      <div className={styles.contents}>
         <div className={styles.inputNumber}>
           <input
             type="number"
@@ -47,15 +60,23 @@ export default function AttendancePad() {
           )}
         </div>
         <div className={styles.numberPad}>
-          {Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 0).map((i) => (
+          {Array(1, 2, 3, 4, 5, 6, 7, 8, 9).map((i) => (
             <button
               key={i}
               className={styles.numberButton}
               onClick={() => handleNumberClick(i)}
+              onKeyDown={(e) => e.preventDefault()}
             >
               {i}
             </button>
           ))}
+          <div></div>
+          <button
+            className={styles.numberButton}
+            onClick={() => handleNumberClick(0)}
+          >
+            0
+          </button>
           <button
             className={styles.previousButton}
             onClick={handlePreviousClick}
@@ -67,6 +88,96 @@ export default function AttendancePad() {
           출석 확인
         </button>
       </div>
+
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) =>
+            attendanceType === "ok" ? (
+              OkModal(onClose)
+            ) : attendanceType === "already" ? (
+              AlreadyModal(onClose)
+            ) : attendanceType === "duplicate" ? (
+              DuplicateMemberModal(onClose)
+            ) : attendanceType === "notfound" ? (
+              NotFoundModal(onClose)
+            ) : (
+              <></>
+            )
+          }
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}
+
+function OkModal(onClose: () => void) {
+  return (
+    <>
+      <ModalHeader className="flex flex-col gap-0">출석</ModalHeader>
+      <ModalBody className={styles.modal__body}>
+        <>
+          <div>출석되었습니다.</div>
+        </>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onPress={onClose}>
+          확인
+        </Button>
+      </ModalFooter>
+    </>
+  );
+}
+
+function AlreadyModal(onClose: () => void) {
+  return (
+    <>
+      <ModalHeader className="flex flex-col gap-0">출석</ModalHeader>
+      <ModalBody className={styles.modal__body}>
+        <>
+          <div>이미 출석하셨습니다.</div>
+        </>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onPress={onClose}>
+          확인
+        </Button>
+      </ModalFooter>
+    </>
+  );
+}
+
+function DuplicateMemberModal(onClose: () => void) {
+  return (
+    <>
+      <ModalHeader className="flex flex-col gap-0">선택하기</ModalHeader>
+      <ModalBody className={styles.modal__body}>
+        <>
+          <div>출석할 인원을 선택해주세요.</div>
+        </>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onPress={onClose}>
+          확인
+        </Button>
+      </ModalFooter>
+    </>
+  );
+}
+
+function NotFoundModal(onClose: () => void) {
+  return (
+    <>
+      <ModalHeader className="flex flex-col gap-0">출석</ModalHeader>
+      <ModalBody className={styles.modal__body}>
+        <>
+          <div>해당하는 인원이 없습니다.</div>
+        </>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onPress={onClose}>
+          확인
+        </Button>
+      </ModalFooter>
     </>
   );
 }

--- a/src/containers/group/detail/contents/AttendancePad.tsx
+++ b/src/containers/group/detail/contents/AttendancePad.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./AttendancePad.module.css";
 import {
   Modal,
@@ -20,6 +21,29 @@ export default function AttendancePad() {
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
   const [attendanceType, setAttendanceType] = useState<AttendanceType>("ok");
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const { key } = event;
+      if (/^\d$/.test(key)) {
+        if (inputNumber.length < 4) {
+          setInputNumber((prev) => prev + key);
+        }
+      } else if (key === "Backspace") {
+        setInputNumber((prev) => prev.slice(0, -1));
+      } else if (key === "Enter" && !isOpen) {
+        handleConfirmClick();
+      } else if (key === "Enter" && isOpen) {
+        onOpenChange();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [inputNumber]);
+
   const handleNumberClick = (number: number) => {
     if (inputNumber.length < 4) {
       setInputNumber(inputNumber + number);
@@ -28,6 +52,10 @@ export default function AttendancePad() {
 
   const handlePreviousClick = () => {
     setInputNumber(inputNumber.slice(0, -1));
+  };
+
+  const handleResetClick = () => {
+    setInputNumber("");
   };
 
   const handleConfirmClick = () => {
@@ -48,13 +76,16 @@ export default function AttendancePad() {
   return (
     <div className={styles.container}>
       <div className={styles.contents}>
+        <h1 className={styles.title}>
+          <span>휴대폰 번호 뒤 4자리</span>를 입력해주세요
+        </h1>
         <div className={styles.inputNumber}>
-          <input
-            type="number"
-            value={inputNumber}
-            maxLength={4}
-            onChange={(e) => setInputNumber(e.target.value)}
-          />
+          <div className={styles.numberDisplay}>
+            <div className={styles.num1}>{inputNumber[0]}</div>
+            <div className={styles.num2}>{inputNumber[1]}</div>
+            <div className={styles.num3}>{inputNumber[2]}</div>
+            <div className={styles.num4}>{inputNumber[3]}</div>
+          </div>
           {errorMessage && (
             <p className={styles.errorMessage}>{errorMessage}</p>
           )}
@@ -77,11 +108,8 @@ export default function AttendancePad() {
           >
             0
           </button>
-          <button
-            className={styles.previousButton}
-            onClick={handlePreviousClick}
-          >
-            ←
+          <button className={styles.resetButton} onClick={handleResetClick}>
+            초기화
           </button>
         </div>
         <button className={styles.confirmButton} onClick={handleConfirmClick}>

--- a/src/services/attendance/attendance.ts
+++ b/src/services/attendance/attendance.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+axios.defaults.baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export type ResponseCode = {
+    code: string;
+};
+
+export const getAttendancePageUniqueCode = async (groupId : number) => {
+    try {
+        const response = await axios.get(`/api/attendance/code/${groupId}`, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")} `,
+            },
+            timeout: 3000,
+        });
+        return response.data as ResponseCode;
+    } catch (error) {
+        console.error(error);
+    }
+}


### PR DESCRIPTION
### 내용
- #59 
- #56 에서 회의한 내용을 바탕으로 화면을 구현했습니다.
- 관리자가 로그인한 디바이스가 아닌 다른 디바이스에서도 출석 화면을 볼 수 있게 고유 링크를 생성하도록 변경했습니다. 아이패드나 다른 노트북 등으로 해당 고유 링크에 접속하여 데스크 같은 곳에서 출석을 받을 수 있도록 합니다.
- 아직 API 미구현 상태입니다. 추후 작업 진행합니다.

### 결과

<img width="1071" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/6588b809-b700-4cda-ab0e-0f2d755767d4">

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/158aa6e5-28ed-4d46-96a4-38edcaf87362