### PR TITLE
[close #67] 공지사항 디자인 수정

### DIFF
--- a/src/containers/group/detail/GroupDetail.tsx
+++ b/src/containers/group/detail/GroupDetail.tsx
@@ -101,7 +101,7 @@ export default function GroupDetail() {
       case "attendance":
         return <Attendance id={id} />;
       case "notice":
-        return <GroupNotice />;
+        return <GroupNotice id={id} groupData={groupData} />;
       case "edit":
         return <GroupManage id={id} groupData={groupData} />;
     }

--- a/src/containers/group/detail/contents/GroupNotice.module.css
+++ b/src/containers/group/detail/contents/GroupNotice.module.css
@@ -45,6 +45,7 @@
 .notice {
     margin-bottom: 1.2rem;
     border-radius: 0.5rem;
+    max-width: 40rem;
     background-color: #fff;
     padding: 1.5rem;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -78,4 +79,19 @@
     background-color: #9DC0FA;
     color: #ffffff;
     cursor: pointer;
+}
+
+.modal_content_title {
+    font-size: 1rem;
+    color: #666666;
+}
+
+.modal_content_textarea {
+    width: 100%;
+    height: 10rem;
+    border: 1px solid #cccccc;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    font-size: 1rem;
+    color: #666666;
 }

--- a/src/containers/group/detail/contents/GroupNotice.tsx
+++ b/src/containers/group/detail/contents/GroupNotice.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 
 import React, { useState, useEffect } from "react";
@@ -11,41 +12,94 @@ import {
   useDisclosure,
   Button,
 } from "@nextui-org/react";
+import { groupInfo } from "@/types/group/group";
 
 type notice = {
   id: number;
   title: string;
   content: string;
-  createdAt: string;
 };
 
-export default function GroupNotice() {
+type GroupNoticeProps = {
+  id: number;
+  groupData: groupInfo | null;
+};
+
+export default function GroupNotice(props: GroupNoticeProps) {
   const [notices, setNotices] = useState<notice[]>([]);
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
+  const [title, setTitle] = useState<string>("");
+  const [message, setMessage] = useState<string>("");
 
-  // 추후 API로 대체
   useEffect(() => {
     async function fetchNotices() {
-      // const response = await fetch("/api/notices");
-      // const data = await response.json();
+      // 추후 API로 대체
+      setTitle(
+        `[${props.groupData?.name}] ${new Date()
+          .toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })
+          .replace("년 ", "년 ")
+          .replace("월 ", "월 ")
+          .replace("일", "일")} 소식입니다.`
+      );
+
+      // 임시 데이터
       setNotices([
         {
           id: 1,
-          title: "공지사항 제목1",
-          content: "내용1",
-          createdAt: "2024-03-23",
+          title: "[테스트그룹] 2024년 5월 4일 소식입니다.",
+          content:
+            "안녕하세요. 테스트그룹입니다. 다름이 아니라 기말고사가 다가오고 있습니다. 이번 기말고사 대비 기간은 5월 22일부터 6월 7일까지입니다. 기간 동안에는 모든 학생들이 기말고사를 준비하도록 합니다. 감사합니다.",
         },
         {
           id: 2,
-          title: "공지사항 제목2",
-          content: "내용2",
-          createdAt: "2024-03-26",
+          title: "[테스트그룹] 2024년 5월 1일 소식입니다.",
+          content:
+            "안녕하세요. 테스트그룹입니다. 금일 5월 1일부터 일주일간 토익 특별 강의가 진행됩니다. 토익을 준비하시는 학생들은 꼭 참석하시기 바랍니다. 감사합니다.",
         },
         {
           id: 3,
-          title: "공지사항 제목3",
-          content: "내용3",
-          createdAt: "2024-03-30",
+          title: "[테스트그룹] 2024년 4월 14일 소식입니다.",
+          content:
+            "안녕하세요. 테스트그룹입니다. 이번 주 토요일에는 4월자 생일 파티가 있습니다. 많은 참석 부탁드립니다.",
+        },
+        {
+          id: 4,
+          title: "[테스트그룹] 2024년 4월 2일 소식입니다.",
+          content: "안녕하세요. 테스트그룹입니다.",
+        },
+        {
+          id: 5,
+          title: "[테스트그룹] 2024년 3월 22일 소식입니다.",
+          content: "안녕하세요. 테스트그룹입니다.",
+        },
+        {
+          id: 6,
+          title: "[테스트그룹] 2024년 3월 14일 소식입니다.",
+          content: "안녕하세요. 테스트그룹입니다.",
+        },
+        {
+          id: 7,
+          title: "[테스트그룹] 2024년 3월 7일 소식입니다.",
+          content: "안녕하세요. 테스트그룹입니다.",
+        },
+        {
+          id: 8,
+          title: "[테스트그룹] 2024년 2월 20일 소식입니다.",
+          content: "안녕하세요. 테스트그룹입니다.",
+        },
+        {
+          id: 9,
+          title: "[테스트그룹] 2024년 2월 13일 소식입니다.",
+          content: "안녕하세요. 테스트그룹입니다.",
+        },
+        {
+          id: 10,
+          title: "[테스트그룹] 2024년 2월 2일 소식입니다.",
+          content: "안녕하세요. 테스트그룹입니다.",
         },
       ]);
     }
@@ -53,17 +107,33 @@ export default function GroupNotice() {
     fetchNotices();
   }, []);
 
+  function requestSendNotice() {
+    // 몌시지 전송 API 호출
+    onOpenChange();
+    alert("소식이 전송되었습니다.");
+    // 공지사항 업데이트
+    setNotices([
+      {
+        id: 1,
+        title: title,
+        content: message,
+      },
+      ...notices,
+    ]);
+    setMessage("");
+  }
+
   return (
     <>
       <h1 className={styles.title}>공지사항</h1>
       <div className={styles.container}>
+        <div className={styles.notice_header}>
+          <div className={styles.title}>보낸 이력</div>
+          <Button color="primary" className={styles.button} onClick={onOpen}>
+            공지 작성
+          </Button>
+        </div>
         <div className={styles.notice_container}>
-          <div className={styles.notice_header}>
-            <div className={styles.title}>보낸 이력</div>
-            <Button color="primary" className={styles.button} onClick={onOpen}>
-              공지 작성
-            </Button>
-          </div>
           {notices.length === 0 ? (
             <div className={styles.empty_notice}>공지사항이 없습니다.</div>
           ) : (
@@ -71,7 +141,6 @@ export default function GroupNotice() {
               <div key={notice.id} className={styles.notice}>
                 <div className={styles.notice_title}>{notice.title}</div>
                 <div className={styles.notice_content}>{notice.content}</div>
-                <div className={styles.notice_date}>{notice.createdAt}</div>
               </div>
             ))
           )}
@@ -87,16 +156,24 @@ export default function GroupNotice() {
               </ModalHeader>
               <ModalBody className={styles.modal__body}>
                 <>
-                  <h3 className={styles.modal__content_Title}>메시지</h3>
+                  <div className={styles.modal_content_title}>
+                    제목: {title}
+                  </div>
                   <textarea
-                    className={styles.message_textarea}
+                    className={styles.modal_content_textarea}
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
                     placeholder="메시지를 입력해주세요."
                   ></textarea>
                 </>
               </ModalBody>
               <ModalFooter>
                 <Button onPress={onClose}>돌아가기</Button>
-                <Button className={styles.send_button} onPress={onClose}>
+                <Button
+                  className={styles.send_button}
+                  onPress={onClose}
+                  onClick={() => requestSendNotice()}
+                >
                   전송하기
                 </Button>
               </ModalFooter>


### PR DESCRIPTION
### 내용
- #67 
- 공지사항은 소속 멤버 모두에게 전송됩니다. 개별 메시지 전송은 인원 관리에서 진행할 수 있습니다.
- 공지사항의 제목은 그룹명과 날짜가 포함되도록 지정됩니다.
- 공지사항 전송 이력을 스크롤하며 조회할 수 있습니다.
- 디자인 확인을 위해 더미 데이터로 구성되었습니다. 추후 API 작업 예정입니다.

### 결과
https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/a0329807-2085-47c7-bfd5-dab923189003