### PR TITLE
[close #75] 그룹 공지사항 기능 구현

### DIFF
--- a/src/containers/group/detail/contents/GroupNotice.module.css
+++ b/src/containers/group/detail/contents/GroupNotice.module.css
@@ -42,6 +42,13 @@
     overflow-y: auto;
 }
 
+.loading {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+
 .notice {
     margin-bottom: 1.2rem;
     border-radius: 0.5rem;

--- a/src/services/attendance/attendance.ts
+++ b/src/services/attendance/attendance.ts
@@ -64,7 +64,7 @@ export const requestAttendanceWithMemberId = async (memberId: number, code: stri
 
 export type AttendanceInfo = {
     attendanceRate: number;
-    notAttendanceMembers: ResponseMembers[];
+    notAttendanceMembers: ResponseMembers[] | [];
 };
 
 export const getAttendanceInfo = async (groupId: number) => {
@@ -72,6 +72,7 @@ export const getAttendanceInfo = async (groupId: number) => {
         const response = await axios.get(`/api/attendances/info/${groupId}`, {
             headers: {
                 "Content-Type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
             }
         });
         return response.data as AttendanceInfo;

--- a/src/services/notice/notice.ts
+++ b/src/services/notice/notice.ts
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+axios.defaults.baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export type ResponseNotice = {
+    id: number;
+    title: string;
+    content: string;
+};
+
+export const getNotices = async (id: number) => {
+    try {
+        const response = await axios.get(`/api/announcements?id=${id}`, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
+        });
+        return response.data as ResponseNotice[];
+    } catch (error) {
+        console.error(error);
+    }
+};
+
+export type RequestCreateNotice = {
+    id: number;
+    title: string;
+    content: string;
+};
+
+export const createNotice = async (request: RequestCreateNotice) => {
+    try {
+        const response = await axios.post(`/api/announcements?id=${request.id}`, {
+            title: request.title,
+            content: request.content,
+        }, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
+        });
+        return response.data;
+    } catch (error) {
+        console.error(error);
+    }
+};


### PR DESCRIPTION
### 내용
- #75 
- 관리자가 그룹 내 인원들에게 일관된 공지를 작성할 수 있습니다. 작성된 공지는 인원의 전화번호를 통해 메시지로 전송됩니다.

### 결과

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/6019921d-7237-44e8-a6fa-9d73359d88af

### 기타
- 출석 정보 조회 API를 사용할 때 헤더에 토큰을 누락하여 추가했습니다.
- 추가로 그룹에 인원이 없는 경우 해당 API에서 오류가 발생합니다! 확인 부탁드립니다. @dd-jiyun 