### PR TITLE
[close #90] 하원 기능 구현

### DIFF
--- a/src/containers/group/detail/contents/AttendancePad.module.css
+++ b/src/containers/group/detail/contents/AttendancePad.module.css
@@ -94,13 +94,32 @@
     background-color: #e6e6e6;
 }
 
-.confirmButton {
+.buttons {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    gap: 2rem;
+    max-width: 400px;
+}
+
+.attendanceButton {
     width: 100%;
     height: 4rem;
     font-size: 1.4rem;
     border: none;
     border-radius: 4px;
     background-color: #9DC0FA;
+    color: #fff;
+    cursor: pointer;
+}
+
+.leavingButton {
+    width: 100%;
+    height: 4rem;
+    font-size: 1.4rem;
+    border: none;
+    border-radius: 4px;
+    background-color: #fc9393;
     color: #fff;
     cursor: pointer;
 }

--- a/src/services/attendance/attendance.ts
+++ b/src/services/attendance/attendance.ts
@@ -62,6 +62,37 @@ export const requestAttendanceWithMemberId = async (memberId: number, code: stri
     }
 }
 
+export const getMembersByLastFourDigitsForLeaving = async (data: RequestMembers) => {
+    try {
+        const response = await axios.get(`/api/attendances/leaving/members?code=${data.code}&phoneNumber=${data.phoneNumber}`,
+        {
+            headers: {
+                "Content-Type": "application/json",
+            },
+            timeout: 3000,
+        });
+        return response.data as ResponseMembers[];
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+export const requestLeavingWithMemberId = async (memberId: number, code: string) => {
+    try {
+        const response = await axios.post(`/api/attendances/leaving/${memberId}`, {
+            code: code,
+        }, {
+            headers: {
+                "Content-Type": "application/json",
+            },
+            timeout: 3000,
+        });
+        return response.data;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
 export type AttendanceInfo = {
     attendanceRate: number;
     notAttendanceMembers: ResponseMembers[] | [];


### PR DESCRIPTION
### 내용
- #90 
- #71 에서 구현한 출석 기능과 함께 사용할 하원 처리 기능을 구현합니다.

### 결과

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/e2b3700e-d54e-4e83-bb9b-2370547ec12e

- 전화번호 뒷 4자리가 같은 인원이 3명(멤버1, 2, 3)이 존재하는 상황에서 테스트한 영상입니다.
- 출석(등원) 기능은 기존과 동일합니다. #71 참고
- 하원은 금일 등원한 인원만 할 수 있습니다.
- 영상에선 나오지 않지만 알림창에 나오는 멘트 중 "출석이 완료되었습니다."를 "등원이 완료되었습니다." 로 변경했습니다.
- 버튼도 마찬가지로 등원 or 하원으로 변경합니다.