### PR TITLE
[close #92] 등하원 직접 수정 화면 구현

### DIFF
--- a/src/containers/group/detail/contents/Attendance.module.css
+++ b/src/containers/group/detail/contents/Attendance.module.css
@@ -2,12 +2,18 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 78vh;
-    padding: 2rem;
+    margin-top: 1rem;
     background-color: #ffffff;
     border-radius: 1rem;
     min-width: 40rem;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 2rem;
 }
 
 .title {
@@ -16,7 +22,33 @@
     color: #333;
     text-align: left;
     padding-left: 0.5rem;
-    margin-bottom: 1rem;
+    padding-bottom: 1.5rem;
+}
+
+.switch {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.switch_button {
+    display: flex;
+    align-items: center;
+    padding: 5px 10px;
+    border-radius: 0.5rem;
+    color: #000000;
+    background-color: #d4d4d4;
+    cursor: pointer;
+}
+
+.switch_button_active {
+    display: flex;
+    align-items: center;
+    padding: 5px 10px;
+    border-radius: 0.5rem;
+    color: #ffffff;
+    cursor: pointer;
+    background-color: #9DC0FA;
 }
 
 .buttonContainer {

--- a/src/containers/group/detail/contents/Attendance.tsx
+++ b/src/containers/group/detail/contents/Attendance.tsx
@@ -20,12 +20,16 @@ import {
   getAttendanceInfo,
   getAttendancePageUniqueCode,
 } from "@/services/attendance/attendance";
+import AttendanceManage from "./AttendanceManage";
+
+type PageType = "info" | "manage";
 
 type AttendanceProps = {
   id: number;
 };
 
 export default function Attendance(props: AttendanceProps) {
+  const [selectedPage, setSelectedPage] = useState<PageType>("info");
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
   const [attendanceCode, setAttendanceCode] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -80,33 +84,64 @@ export default function Attendance(props: AttendanceProps) {
   return (
     <>
       <h1 className={styles.title}>출결 관리</h1>
+      <div className={styles.switch}>
+        <Button
+          className={
+            selectedPage === "info"
+              ? styles.switch_button_active
+              : styles.switch_button
+          }
+          onPress={() => setSelectedPage("info")}
+        >
+          출결 현황
+        </Button>
+        <Button
+          className={
+            selectedPage === "manage"
+              ? styles.switch_button_active
+              : styles.switch_button
+          }
+          onPress={() => setSelectedPage("manage")}
+        >
+          출결 관리
+        </Button>
+      </div>
       <div className={styles.container}>
-        <div className={styles.buttonContainer}>
-          <Button className={styles.button} onClick={generateAttendanceCode}>
-            출석 링크
-          </Button>
-        </div>
-        <div className={styles.summary}>
-          <Progress
-            label="금일 출석률"
-            aria-label="Downloading..."
-            size="md"
-            value={attendanceRate}
-            color="primary"
-            showValueLabel={true}
-            className={styles.attendanceRate}
-          />
-          <div className={styles.absent}>
-            <h3 className={styles.absentTitle}>금일 미출석 인원</h3>
-            <ul className={styles.absentList}>
-              {absentMembers.map((member) => (
-                <li key={member.memberId} className={styles.absentMembers}>
-                  {member.memberName}
-                </li>
-              ))}
-            </ul>
+        {selectedPage === "info" ? (
+          <div className={styles.content}>
+            <div className={styles.buttonContainer}>
+              <Button
+                className={styles.button}
+                onClick={generateAttendanceCode}
+              >
+                출석 링크
+              </Button>
+            </div>
+            <div className={styles.summary}>
+              <Progress
+                label="금일 출석률"
+                aria-label="Downloading..."
+                size="md"
+                value={attendanceRate}
+                color="primary"
+                showValueLabel={true}
+                className={styles.attendanceRate}
+              />
+              <div className={styles.absent}>
+                <h3 className={styles.absentTitle}>금일 미출석 인원</h3>
+                <ul className={styles.absentList}>
+                  {absentMembers.map((member) => (
+                    <li key={member.memberId} className={styles.absentMembers}>
+                      {member.memberName}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
           </div>
-        </div>
+        ) : (
+          <AttendanceManage id={props.id} />
+        )}
       </div>
 
       <Modal

--- a/src/containers/group/detail/contents/AttendanceManage.module.css
+++ b/src/containers/group/detail/contents/AttendanceManage.module.css
@@ -1,0 +1,144 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 100%;
+    height: 44vh;
+    min-height: 44rem;
+    padding: 2rem;
+    background-color: #ffffff;
+    min-width: 40rem;
+    border-radius: 1rem;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.searchInput {
+    display: flex;
+    align-items: center;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 12px;
+    padding: 5px 10px;
+    margin-right: 10px;
+}
+
+.controll_buttons {
+    display: flex;
+    gap: 10px;
+}
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.list_item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-radius: 8px;
+    padding-right: 0.5rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease-in-out;
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+    background-color: #fff;
+}
+
+.list_item_name {
+    width: 100%;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    padding-left: 1rem;
+    border-radius: 8px;
+}
+
+.list_item:hover {
+    background-color: #f5f5f5;
+}
+
+.buttons {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.button_normal {
+    background-color: #f6f6f6;
+    color: #000000;
+}
+
+.button_attendance {
+    background-color: #1bda25c7;
+    color: #fff;
+}
+
+.button_absence {
+    background-color: #e74242d8;
+    color: #fff;
+}
+
+.button_leave {
+    background-color: #9948e9d1;
+    color: #fff;
+}
+
+.button_image {
+    margin-left: 0.5rem;
+    padding: 0.5rem;
+    cursor: pointer;
+}
+
+.button_image:hover {
+    border: 1px solid #c1c1c1;
+}
+
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.pagination button {
+    margin: 0 5px;
+    padding: 5px 10px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease-in-out;
+    background-color: #fff;
+    color: #333;
+}
+
+.pagination .currentPage {
+    background-color: #9DC0FA;
+    color: #fff;
+}
+
+.pagination button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+}
+
+.pagination .firstPage {
+    border-radius: 8px 0 0 8px;
+}
+
+.pagination .lastPage {
+    border-radius: 0 8px 8px 0;
+}
+
+.pagination .prevPage {
+    margin-right: 10px;
+}
+
+.pagination .nextPage {
+    margin-left: 10px;
+}

--- a/src/containers/group/detail/contents/AttendanceManage.tsx
+++ b/src/containers/group/detail/contents/AttendanceManage.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import styles from "./AttendanceManage.module.css";
+import { Pagination, Link, Button } from "@nextui-org/react";
+import usePagination from "@/hooks/usePagination";
+import { getGroupMembers } from "@/services/member/member";
+import { member, memberForAttendance } from "@/types/user/member";
+
+type AttendanceManageProps = {
+  id: number;
+};
+
+export default function AttendanceManage(props: AttendanceManageProps) {
+  const [members, setMembers] = useState<memberForAttendance[]>([]);
+  const [currentMembers, setCurrentMembers] = useState<memberForAttendance[]>(
+    []
+  );
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const { currentPage, totalPages, setTotalItems, setPage } = usePagination(1);
+
+  const filteredMembers = useMemo(() => {
+    if (searchKeyword) {
+      return members.filter((member) =>
+        member.name.toLowerCase().includes(searchKeyword.toLowerCase())
+      );
+    } else {
+      return members;
+    }
+  }, [members, searchKeyword]);
+
+  // API 구현 예정
+  //   useEffect(() => {
+  //     const data = getGroupMembers(props.id);
+  //     data.then((data) => {
+  //       setMembers(data);
+  //     });
+  //   }, [props.id]);
+
+  useEffect(() => {
+    setMembers([
+      {
+        id: 1,
+        name: "김철수",
+        status: 0,
+      },
+      {
+        id: 2,
+        name: "이영희",
+        status: 1,
+      },
+      {
+        id: 3,
+        name: "박민수",
+        status: 1,
+      },
+      {
+        id: 4,
+        name: "최영수",
+        status: 0,
+      },
+      {
+        id: 5,
+        name: "김민지",
+        status: 0,
+      },
+      {
+        id: 6,
+        name: "박민지",
+        status: 3,
+      },
+      {
+        id: 7,
+        name: "이민지",
+        status: 3,
+      },
+      {
+        id: 8,
+        name: "최민지",
+        status: 3,
+      },
+      {
+        id: 9,
+        name: "김민수",
+        status: 0,
+      },
+      {
+        id: 10,
+        name: "박민수",
+        status: 1,
+      },
+      {
+        id: 11,
+        name: "이민수",
+        status: 1,
+      },
+      {
+        id: 12,
+        name: "최민수",
+        status: 0,
+      },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    const start = (currentPage - 1) * 7;
+    const end = start + 7;
+    setCurrentMembers(filteredMembers.slice(start, end));
+    setTotalItems(filteredMembers.length);
+  }, [currentPage, filteredMembers, setTotalItems]);
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(e.target.value);
+  };
+
+  const createButtonsByMemberStatus = (status: number) => {
+    switch (status) {
+      case 0:
+        return (
+          <>
+            <Button size="md" className={styles.button_attendance} disabled>
+              등원
+            </Button>
+            <Button size="md" className={styles.button_normal}>
+              결석
+            </Button>
+            <Button size="md" className={styles.button_normal}>
+              하원
+            </Button>
+          </>
+        );
+      case 1:
+        return (
+          <>
+            <Button size="md" className={styles.button_normal}>
+              등원
+            </Button>
+            <Button size="md" className={styles.button_absence} disabled>
+              결석
+            </Button>
+            <Button size="md" className={styles.button_normal}>
+              하원
+            </Button>
+          </>
+        );
+      case 3:
+        return (
+          <>
+            <Button size="md" className={styles.button_normal}>
+              등원
+            </Button>
+            <Button size="md" className={styles.button_normal}>
+              결석
+            </Button>
+            <Button size="md" className={styles.button_leave} disabled>
+              하원
+            </Button>
+          </>
+        );
+      default:
+        return (
+          <>
+            <Button size="md" className={styles.button_attendance} disabled>
+              등원
+            </Button>
+            <Button size="md" className={styles.button_absence} disabled>
+              결석
+            </Button>
+            <Button size="md" className={styles.button_leave} disabled>
+              하원
+            </Button>
+          </>
+        );
+    }
+  };
+
+  return (
+    <>
+      <div className={styles.container}>
+        <div className={styles.content}>
+          <div className={styles.header}>
+            <input
+              type="text"
+              placeholder="이름 검색"
+              value={searchKeyword}
+              onChange={handleSearch}
+              className={styles.searchInput}
+            />
+            <div className={styles.controll_buttons}>
+              <Button size="md" className={styles.button_attendance}>
+                전체 출석
+              </Button>
+              <Button size="md" className={styles.button_leave}>
+                전체 하원
+              </Button>
+            </div>
+          </div>
+          <div className={styles.list}>
+            {filteredMembers.length === 0 && <div>인원이 없습니다.</div>}
+            {currentMembers.map((member) => (
+              <div key={member.id} className={styles.list_item}>
+                <div className={styles.list_item_name}>{member.name}</div>
+                <div className={styles.buttons}>
+                  {createButtonsByMemberStatus(member.status)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className={styles.pagination}>
+          <Pagination
+            showControls
+            total={totalPages}
+            initialPage={1}
+            onChange={(page) => setPage(page)}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/containers/group/detail/contents/GroupManage.module.css
+++ b/src/containers/group/detail/contents/GroupManage.module.css
@@ -3,7 +3,6 @@
     flex-direction: column;
     width: 45rem;
     min-width: 45rem;
-    height: 78vh;
     padding: 2rem;
     background-color: #ffffff;
     flex-grow: 1;

--- a/src/types/user/member.ts
+++ b/src/types/user/member.ts
@@ -5,3 +5,9 @@ export type member = {
     birth: string;
     specifics: string;
 };
+
+export type memberForAttendance = {
+    id: number;
+    name: string;
+    status: number;
+};


### PR DESCRIPTION
### 내용
- #92 
- 관리자가 그룹 인원들의 등하원(출결)을 직접 수정할 수 있는 화면을 구현합니다.

### 결과

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/7d701890-ec8a-44a7-b3fc-c895d073e5a2

중복 인원 판별 방법 및 검색 시 정렬이 아직 구현되지 않았습니다.
데이터는 하드 코딩 된 임시 데이터입니다.
한 번 확인 후 피드백 부탁드려요! @dd-jiyun 

### 예시 사진

<img width="240" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/1b3e1e59-3111-4d88-870c-6a7d5b44bd20">

### 요청 사항

```json
{
    "id": 1,
    "name": "이름",
    "status": "출석 상태(0: 출석, 1: 결석, 3: 하원)"
}
```
해당 페이지를 위해 꼭 필요한 응답 필드입니다! 아니면 예전에 인원 관리 페이지(#73)에서 사용한 API에 출석 상태만 추가해줘도 좋은 것 같아요!