### PR TITLE
[close #94] 등하원 직접 수정 기능 구현

### DIFF
--- a/src/containers/group/detail/contents/Attendance.tsx
+++ b/src/containers/group/detail/contents/Attendance.tsx
@@ -56,7 +56,7 @@ export default function Attendance(props: AttendanceProps) {
     };
 
     fetchAttendanceInfo();
-  }, [props.id]);
+  }, [props.id, selectedPage]);
 
   const generateAttendanceCode = async () => {
     onOpen();

--- a/src/services/attendance/attendance.ts
+++ b/src/services/attendance/attendance.ts
@@ -111,3 +111,65 @@ export const getAttendanceInfo = async (groupId: number) => {
         console.error(error);
     }
 };
+
+export type MemberWithAttendanceStatus = {
+    memberId: number;
+    memberName: string;
+    status: string;
+}
+
+export const getMembersWithAttendanceStatus = async (groupId: number) => {
+    try {
+        const response = await axios.get(`/api/attendances/members/${groupId}`, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
+        });
+        return response.data as MemberWithAttendanceStatus[];
+    } catch (error) {
+        console.error(error);
+    }
+};
+
+export enum AttendanceStatus {
+    ATTENDANCE = "ATTENDANCE",
+    ABSENCE = "ABSENCE",
+    ILLNESS = "ILLNESS",
+    LEAVING = "LEAVING",
+}
+
+export namespace AttendanceStatus {
+    export function of(status: string): AttendanceStatus {
+        switch (status) {
+            case "ATTENDANCE":
+                return AttendanceStatus.ATTENDANCE;
+            case "ABSENCE":
+                return AttendanceStatus.ABSENCE;
+            case "ILLNESS":
+                return AttendanceStatus.ILLNESS;
+            case "LEAVING":
+                return AttendanceStatus.LEAVING;
+            default:
+                throw new Error(`Unknown status: ${status}`);
+        }
+    }
+}
+
+export type RequestUpdateAttendanceStatus = {
+    memberId: number;
+    status: string;
+};
+
+export const updateAttendanceStatus = async (data: RequestUpdateAttendanceStatus) => {
+    try {
+        await axios.put(`/api/attendances/members/${data.memberId}?status=${data.status}`, {}, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+            }
+        });
+    } catch (error) {
+        console.error(error);
+    }
+};

--- a/src/types/user/member.ts
+++ b/src/types/user/member.ts
@@ -5,9 +5,3 @@ export type member = {
     birth: string;
     specifics: string;
 };
-
-export type memberForAttendance = {
-    id: number;
-    name: string;
-    status: number;
-};


### PR DESCRIPTION
### 내용
- #94 
- #92 에서 구현한 화면에 맞게 출석, 결석 등을 관리자가 직접 수정할 수 있는 기능을 구현합니다.
- 등하원 정보를 직접 수정 후 새로운 정보를 볼 수 있도록 수정합니다.

### 결과

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/69943aae-e565-4ee3-9baa-5e032c7dc6a0

### 하원 출석률 이슈 개선 결과

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/4879d0b7-dc0c-42d7-8ff2-d3a72f58fe7b

