### PR TITLE
[close #102] 출결 관리 화면 UX 향상

### DIFF
--- a/src/services/attendance/attendance.ts
+++ b/src/services/attendance/attendance.ts
@@ -169,8 +169,10 @@ export const updateAttendanceStatus = async (data: RequestUpdateAttendanceStatus
                 "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
             }
         });
+        return { status: 200 };
     } catch (error) {
         console.error(error);
+        return { status: 500 };
     }
 };
 
@@ -182,7 +184,9 @@ export const updateAttendanceStatusAll = async (groupId: number, status: number)
                 "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
             }
         });
+        return { status: 200 };
     } catch (error) {
         console.error(error);
+        return { status: 500 };
     }
 };


### PR DESCRIPTION
### 내용
- #102 
- 현재 구현된 출결 관리 화면에서는 API 요청(출석 상태 변경 요청)의 응답이 도착하면 UI를 변경하도록 구현되어 있습니다.
- 하지만 관리자(사용자) 입장에서는 버튼을 누른 후 일정 기간이 지나야 UI가 반영되는 것을 반갑게 여기지 않을 것입니다. 이를 고민하고 개선한 결과입니다.

### 코드
```tsx
const requestUpdateAttendanceStatusAll = async (status: number) => {
    // 이전 상태 저장
    const beforeMembers = members;

    // UI 미리 변경
    const updatedMembers = members.map((member) => {
        return {
            ...member,
            status: status === 0 ? "ATTENDANCE" : "LEAVING", // 현재는 전체 등하원 조작만 가능합니다.
        };
    });
    setMembers(updatedMembers);

    // API 호출
    const response = await updateAttendanceStatusAll(props.id, status);

    // API 호출 실패 시 UI 원복
    if (response.status !== 200) {
        alert("출석 상태 변경에 실패했습니다.");
        setMembers(beforeMembers);
    }
};
```

버튼을 누르면 이전 상태를 잠시 저장하고, 즉시 UI에 반영합니다. 만약 API 통신에 문제가 생겼을 경우 알림을 띄우고 이전 상태로 되돌립니다.

### 변경 전

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/4e30abd8-8961-44b8-96fa-27fa98429358

- 버튼을 누르고 일정 기간 기다려야 UI에 반영됩니다.

### 변경 후 (API 요청 성공)

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/110e5c36-ef59-4e3f-965c-a3bfdcdebaa6

- 버튼을 누르는 즉시 UI에 반영됩니다.

### 변경 후 (API 요청 실패 테스트)

https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/8f5d9f40-9c32-4d85-9c7b-65e1f569f80d

- 만약 API 호출에 문제가 생기면 이전 상태로 되돌립니다.
- API 요청이 성공하는 일이 더 많기 때문에 미리 반영하고 실패하면 원복하는 방식을 선택했습니다.