### PR TITLE
[close #109] 이미지 이름 생성 방식 보완

### DIFF
--- a/src/containers/group/detail/contents/GroupManage.tsx
+++ b/src/containers/group/detail/contents/GroupManage.tsx
@@ -110,14 +110,21 @@ export default function GroupManage(props: GroupManageProps) {
   };
 
   const uploadGroupImage = (imageFile: File | null) => {
+    // 이미지 파일이 없을 경우
     if (!imageFile) {
       return;
     }
-    const uploadFileName = uuid() + ".png";
+
+    // 이미지 파일 이름 생성 및 프리뷰 이미지 설정
+    const timestamp = new Date(Date.now()).toISOString();
+    const uniqueValue = uuid();
+    const uploadFileName = `${timestamp}_${uniqueValue}.png`;
     setImageName(uploadFileName);
+    setPreviewImage(imageFile);
+
+    // 이미지 업로드
     const imageRef = ref(firebaseStorage, uploadFileName);
     uploadBytes(imageRef, imageFile);
-    setPreviewImage(imageFile);
   };
 
   const requestUpdateGroup = async () => {


### PR DESCRIPTION
### 내용
- #109 
- uuid v4는 중복될 확률이 매우 적다는 것을 알고 있지만, 파이어베이스에서 저장된 이미지를 볼 때 더욱 보기 쉽고 확률을 조금이라도 더 줄이고 싶었습니다. 하지만 데이터베이스에 이미지 파일명이 저장될 때 검색 성능은 추후 함께 생각해봐야 할 것 같습니다. 지금은 그룹 대표 이미지에서만 사용하기 때문에 추가합니다.
- 혹시 모를 중복을 대비하고 파일을 눈으로 쉽게 찾을 수 있도록 이미지 이름을 생성할 때 타임스탬프 정보도 추가합니다.
<img width="481" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Web/assets/107793780/84e2a939-9583-47fd-905c-297b05895de4">